### PR TITLE
Add support for optional $id fields on node and relationship object types properties

### DIFF
--- a/.changeset/great-falcons-move.md
+++ b/.changeset/great-falcons-move.md
@@ -1,0 +1,6 @@
+---
+"@neo4j/graph-schema-utils": patch
+"@neo4j/graph-json-schema": patch
+---
+
+Add support for optional $id fields on node and relationship object types

--- a/packages/graph-schema-utils/src/model/index.ts
+++ b/packages/graph-schema-utils/src/model/index.ts
@@ -83,7 +83,8 @@ export class GraphSchema {
             new Property(
               property.token,
               PropertyType.fromJsonStruct(property.type),
-              property.mandatory
+              property.mandatory,
+              property.$id
             )
         )
       );
@@ -125,7 +126,8 @@ export class GraphSchema {
               new Property(
                 property.token,
                 PropertyType.fromJsonStruct(property.type),
-                property.mandatory
+                property.mandatory,
+                property.$id
               )
           )
         );
@@ -255,15 +257,18 @@ export class Property {
   token: string;
   type: PropertyTypes | PropertyTypes[];
   mandatory: boolean | undefined;
+  $id: string | undefined;
 
   constructor(
     token: string,
     type: PropertyBaseType | PropertyArrayType,
-    mandatory?: boolean
+    mandatory?: boolean,
+    $id?: string
   ) {
     this.token = token;
     this.type = type;
     this.mandatory = mandatory;
+    this.$id = $id;
   }
   toJsonStruct() {
     const typeVal = Array.isArray(this.type)
@@ -275,6 +280,9 @@ export class Property {
     };
     if (this.mandatory !== undefined) {
       out["mandatory"] = this.mandatory;
+    }
+    if (this.$id !== undefined) {
+      out["$id"] = this.$id;
     }
     return out;
   }

--- a/packages/graph-schema-utils/test/model/programatical.test.ts
+++ b/packages/graph-schema-utils/test/model/programatical.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from "node:assert";
-import { describe, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { model } from "../../src/index.js";
 import { PropertyTypes } from "../../src/model/index.js";
 
@@ -113,5 +113,35 @@ describe("Programatic model tests", () => {
       ).type,
       "array"
     );
+  });
+  test("Handles optional id:s on properties", () => {
+    const properties = [
+      new model.Property("name", new model.PropertyBaseType("string")),
+      new model.Property(
+        "age",
+        new model.PropertyBaseType("integer"),
+        true,
+        "test-id"
+      ),
+    ];
+    const serialized = properties.map((p) => p.toJsonStruct());
+    expect(serialized).toMatchInlineSnapshot(`
+      [
+        {
+          "token": "name",
+          "type": {
+            "type": "string",
+          },
+        },
+        {
+          "$id": "test-id",
+          "mandatory": true,
+          "token": "age",
+          "type": {
+            "type": "integer",
+          },
+        },
+      ]
+    `);
   });
 });

--- a/packages/graph-schema-utils/test/model/test-schemas/full.json
+++ b/packages/graph-schema-utils/test/model/test-schemas/full.json
@@ -44,7 +44,11 @@
           "properties": [
             { "token": "id", "mandatory": false, "type": { "type": "string" } },
             { "token": "name", "type": { "type": "string" } },
-            { "token": "born", "type": { "type": "integer" } }
+            {
+              "$id": "born-property",
+              "token": "born",
+              "type": { "type": "integer" }
+            }
           ]
         },
         {

--- a/packages/graph-schema-utils/test/validation/test-schemas/optional-id.json
+++ b/packages/graph-schema-utils/test/validation/test-schemas/optional-id.json
@@ -1,0 +1,27 @@
+{
+  "graphSchemaRepresentation": {
+    "version": "1.0.1",
+    "graphSchema": {
+      "nodeLabels": [],
+      "relationshipTypes": [],
+      "nodeObjectTypes": [
+        {
+          "$id": "test-id",
+          "labels": [{ "$ref": "#nl:Person" }],
+          "properties": [
+            {
+              "$id": "xxxxx",
+              "token": "has-id",
+              "type": { "type": "string" }
+            },
+            {
+              "token": "no-id",
+              "type": { "type": "string" }
+            }
+          ]
+        }
+      ],
+      "relationshipObjectTypes": []
+    }
+  }
+}

--- a/packages/graph-schema-utils/test/validation/validation.test.js
+++ b/packages/graph-schema-utils/test/validation/validation.test.js
@@ -31,4 +31,11 @@ describe("Validate if JSON-documen is a string", () => {
     );
     assert.throws(() => validateSchema(JSON_SCHEMA, NON_JSON), InputTypeError);
   });
+  test("Handles optional id:s on properties", () => {
+    const schema = readFile(
+      path.resolve(__dirname, "./test-schemas/optional-id.json")
+    );
+    validateSchema(JSON_SCHEMA, schema);
+    assert.doesNotThrow(() => validateSchema(JSON_SCHEMA, schema));
+  });
 });

--- a/packages/json-schema/json-schema.json
+++ b/packages/json-schema/json-schema.json
@@ -1,9 +1,8 @@
 {
-  
   "type": "object",
   "properties": {
-    "$schema":{
-      "type":"string"
+    "$schema": {
+      "type": "string"
     },
     "graphSchemaRepresentation": {
       "type": "object",
@@ -149,6 +148,7 @@
                 "type": "string"
               },
               "mandatory": { "type": "boolean" },
+              "$id": { "type": "string" },
               "type": {
                 "oneOf": [
                   {


### PR DESCRIPTION
For more predictable reference-ability from external sources.
Example

```json
[
  { "token": "name", "type": { "type": "string" } },
  {
    "$id": "born-property",
    "token": "born",
    "type": { "type": "integer" }
  }
]
```