### PR TITLE
Add model helper functions & fix property type param

### DIFF
--- a/.changeset/perfect-moons-leave.md
+++ b/.changeset/perfect-moons-leave.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graph-schema-utils": patch
+---
+
+Add model helper functions and fix Property type issues

--- a/packages/graph-schema-utils/src/model/index.ts
+++ b/packages/graph-schema-utils/src/model/index.ts
@@ -294,9 +294,7 @@ export class Property {
     return out;
   }
   toRef() {
-    return {
-      $ref: `#${this.$id}`,
-    };
+    return this.$id !== undefined ? { $ref: `#${this.$id}` } : null;
   }
 }
 

--- a/packages/graph-schema-utils/src/model/index.ts
+++ b/packages/graph-schema-utils/src/model/index.ts
@@ -265,7 +265,7 @@ export type PropertyTypes = PropertyBaseType | PropertyArrayType;
 export class Property {
   token: string;
   type: PropertyTypes | PropertyTypes[];
-  nullable: boolean | undefined;
+  nullable: boolean;
   $id: string | undefined;
 
   constructor(

--- a/packages/graph-schema-utils/src/model/index.ts
+++ b/packages/graph-schema-utils/src/model/index.ts
@@ -8,12 +8,16 @@ export class GraphSchemaRepresentation {
   }
 
   toJson() {
-    return JSON.stringify({
+    return JSON.stringify(this.toJsonStruct());
+  }
+
+  toJsonStruct() {
+    return {
       graphSchemaRepresentation: {
         version: this.version,
         graphSchema: this.graphSchema.toJsonStruct(),
       },
-    });
+    };
   }
 
   static parseJson(jsonString) {
@@ -250,6 +254,11 @@ export class RelationshipObjectType {
       properties: this.properties.map((property) => property.toJsonStruct()),
     };
   }
+  toRef() {
+    return {
+      $ref: `#${this.$id}`,
+    };
+  }
 }
 
 export type PropertyTypes = PropertyBaseType | PropertyArrayType;
@@ -261,7 +270,7 @@ export class Property {
 
   constructor(
     token: string,
-    type: PropertyBaseType | PropertyArrayType,
+    type: PropertyTypes | PropertyTypes[],
     nullable: boolean,
     $id?: string
   ) {
@@ -283,6 +292,11 @@ export class Property {
       out["$id"] = this.$id;
     }
     return out;
+  }
+  toRef() {
+    return {
+      $ref: `#${this.$id}`,
+    };
   }
 }
 

--- a/packages/graph-schema-utils/src/model/index.ts
+++ b/packages/graph-schema-utils/src/model/index.ts
@@ -321,7 +321,7 @@ export class PropertyArrayType {
   toJsonStruct() {
     return {
       type: this.type,
-      items: this.items,
+      items: this.items.toJsonStruct(),
     };
   }
 }
@@ -332,7 +332,7 @@ export class PropertyType {
       return json.map((item) => PropertyType.fromJsonStruct(item));
     }
     if (json.type === "array") {
-      return new PropertyArrayType(json.items);
+      return new PropertyArrayType(new PropertyBaseType(json.items.type));
     }
     return new PropertyBaseType(json.type);
   }

--- a/packages/graph-schema-utils/test/model/parse.test.ts
+++ b/packages/graph-schema-utils/test/model/parse.test.ts
@@ -39,13 +39,10 @@ describe("Parser tests", () => {
     );
     // handles array of types
     assert.deepEqual(
-      // the map here is just to make it a plain object to pass the comparison
       (
         parsed.graphSchema.nodeObjectTypes[0].properties[0]
           .type as PropertyTypes[]
-      ).map((pbt) => ({
-        ...pbt,
-      })),
+      ).map((pbt) => pbt.toJsonStruct()),
       rawParsed.graphSchemaRepresentation.graphSchema.nodeObjectTypes[0]
         .properties[0].type
     );

--- a/packages/graph-schema-utils/test/model/programatical.test.ts
+++ b/packages/graph-schema-utils/test/model/programatical.test.ts
@@ -182,7 +182,7 @@ describe("Programatic model tests", () => {
           "nullable": false,
           "token": "name",
           "type": {
-            "items": PropertyBaseType {
+            "items": {
               "type": "string",
             },
             "type": "array",
@@ -208,7 +208,7 @@ describe("Programatic model tests", () => {
               "type": "float",
             },
             {
-              "items": PropertyBaseType {
+              "items": {
                 "type": "datetime",
               },
               "type": "array",

--- a/packages/graph-schema-utils/test/model/programatical.test.ts
+++ b/packages/graph-schema-utils/test/model/programatical.test.ts
@@ -99,6 +99,9 @@ describe("Programatic model tests", () => {
       gRep.graphSchema.relationshipObjectTypes[0].to,
       nodeObjectTypes[1]
     );
+    assert.deepEqual(gRep.graphSchema.relationshipObjectTypes[0].toRef(), {
+      $ref: "#r1",
+    });
     assert.strictEqual(
       gRep.graphSchema.relationshipObjectTypes[0].properties.length,
       1
@@ -142,6 +145,75 @@ describe("Programatic model tests", () => {
           "type": {
             "type": "integer",
           },
+        },
+      ]
+    `);
+    expect(properties[0]?.toRef()).toEqual(null);
+    expect(properties[1]?.toRef()).toEqual({ $ref: "#test-id" });
+  });
+  test("Allows creation of properties with complicated types", () => {
+    const properties = [
+      new model.Property(
+        "name",
+        new model.PropertyArrayType(new model.PropertyBaseType("string")),
+        false
+      ),
+      new model.Property(
+        "id",
+        [
+          new model.PropertyBaseType("integer"),
+          new model.PropertyBaseType("string"),
+        ],
+        false
+      ),
+      new model.Property(
+        "another",
+        [
+          new model.PropertyBaseType("float"),
+          new model.PropertyArrayType(new model.PropertyBaseType("datetime")),
+        ],
+        false
+      ),
+    ];
+    const serialized = properties.map((p) => p.toJsonStruct());
+    expect(serialized).toMatchInlineSnapshot(`
+      [
+        {
+          "nullable": false,
+          "token": "name",
+          "type": {
+            "items": PropertyBaseType {
+              "type": "string",
+            },
+            "type": "array",
+          },
+        },
+        {
+          "nullable": false,
+          "token": "id",
+          "type": [
+            {
+              "type": "integer",
+            },
+            {
+              "type": "string",
+            },
+          ],
+        },
+        {
+          "nullable": false,
+          "token": "another",
+          "type": [
+            {
+              "type": "float",
+            },
+            {
+              "items": PropertyBaseType {
+                "type": "datetime",
+              },
+              "type": "array",
+            },
+          ],
         },
       ]
     `);

--- a/packages/graph-schema-utils/test/model/serialize.test.ts
+++ b/packages/graph-schema-utils/test/model/serialize.test.ts
@@ -22,10 +22,16 @@ describe("Serializer tests", () => {
     assert.strictEqual(validation, true);
   });
 
-  test("Can parse a graph schema and serialize it to be the same", () => {
+  test("Can parse a graph schema and serialize it to be the same string", () => {
     const parsed = model.GraphSchemaRepresentation.parseJson(fullSchema);
     const serialized = parsed.toJson();
     assert.deepEqual(JSON.parse(serialized), JSON.parse(fullSchema));
+  });
+
+  test("Can parse a graph schema and serialize it to be the same json struct", () => {
+    const parsed = model.GraphSchemaRepresentation.parseJson(fullSchema);
+    const serializedStruct = parsed.toJsonStruct();
+    assert.deepEqual(serializedStruct, JSON.parse(fullSchema));
   });
 
   test("Throws if label refs aren't connected", () => {


### PR DESCRIPTION
- Added `GraphSchemaRepresentation.toJsonStruct` in addition to existing `toJson` function, so that data importer can use it in its `DataModel.toJson` function instead of faffing with `JSON.parse`
- Added a couple of `toRef` functions as they're useful in data importer
- Fixed the `type` param in the `Property` constructor