### PR TITLE
Add convenience methods to extract parts of the schema

### DIFF
--- a/.changeset/rich-cameras-drive.md
+++ b/.changeset/rich-cameras-drive.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graph-schema-utils": patch
+---
+
+Add convenient extraction methods to GraphSchema

--- a/packages/graph-schema-utils/src/model/index.ts
+++ b/packages/graph-schema-utils/src/model/index.ts
@@ -7,28 +7,6 @@ export class GraphSchemaRepresentation {
     this.graphSchema = graphSchema;
   }
 
-  getAllNodeLabelTokens() {
-    return this.graphSchema.nodeLabels.map((nodeLabel) => nodeLabel.token);
-  }
-
-  getAllRelationshipTypeTokens() {
-    return this.graphSchema.relationshipTypes.map(
-      (relationshipType) => relationshipType.token
-    );
-  }
-
-  getAllPropertyTokens() {
-    const nodeProperties = this.graphSchema.nodeObjectTypes.flatMap(
-      (nodeObjectType) => nodeObjectType.getPropertyTokens()
-    );
-    const relationshipProperties =
-      this.graphSchema.relationshipObjectTypes.flatMap(
-        (relationshipObjectType) => relationshipObjectType.getPropertyTokens()
-      );
-    // return all tokens without duplicates
-    return [...new Set([...nodeProperties, ...relationshipProperties])];
-  }
-
   toJson() {
     return JSON.stringify(this.toJsonStruct());
   }
@@ -82,6 +60,27 @@ export class GraphSchema {
         (relationshipObjectType) => relationshipObjectType.toJsonStruct()
       ),
     };
+  }
+
+  getAllNodeLabelTokens() {
+    return this.nodeLabels.map((nodeLabel) => nodeLabel.token);
+  }
+
+  getAllRelationshipTypeTokens() {
+    return this.relationshipTypes.map(
+      (relationshipType) => relationshipType.token
+    );
+  }
+
+  getAllPropertyTokens() {
+    const nodeProperties = this.nodeObjectTypes.flatMap((nodeObjectType) =>
+      nodeObjectType.getPropertyTokens()
+    );
+    const relationshipProperties = this.relationshipObjectTypes.flatMap(
+      (relationshipObjectType) => relationshipObjectType.getPropertyTokens()
+    );
+    // return all tokens without duplicates
+    return [...new Set([...nodeProperties, ...relationshipProperties])];
   }
 
   static fromJsonStruct(json) {

--- a/packages/graph-schema-utils/src/model/index.ts
+++ b/packages/graph-schema-utils/src/model/index.ts
@@ -7,6 +7,28 @@ export class GraphSchemaRepresentation {
     this.graphSchema = graphSchema;
   }
 
+  getAllNodeLabelTokens() {
+    return this.graphSchema.nodeLabels.map((nodeLabel) => nodeLabel.token);
+  }
+
+  getAllRelationshipTypeTokens() {
+    return this.graphSchema.relationshipTypes.map(
+      (relationshipType) => relationshipType.token
+    );
+  }
+
+  getAllPropertyTokens() {
+    const nodeProperties = this.graphSchema.nodeObjectTypes.flatMap(
+      (nodeObjectType) => nodeObjectType.getPropertyTokens()
+    );
+    const relationshipProperties =
+      this.graphSchema.relationshipObjectTypes.flatMap(
+        (relationshipObjectType) => relationshipObjectType.getPropertyTokens()
+      );
+    // return all tokens without duplicates
+    return [...new Set([...nodeProperties, ...relationshipProperties])];
+  }
+
   toJson() {
     return JSON.stringify(this.toJsonStruct());
   }
@@ -214,6 +236,9 @@ export class NodeObjectType {
       $ref: `#${this.$id}`,
     };
   }
+  getPropertyTokens() {
+    return this.properties.map((property) => property.token);
+  }
 }
 
 export class RelationshipObjectType {
@@ -258,6 +283,9 @@ export class RelationshipObjectType {
     return {
       $ref: `#${this.$id}`,
     };
+  }
+  getPropertyTokens() {
+    return this.properties.map((property) => property.token);
   }
 }
 

--- a/packages/graph-schema-utils/test/model/programatical.test.ts
+++ b/packages/graph-schema-utils/test/model/programatical.test.ts
@@ -225,10 +225,8 @@ describe("Programatic model tests", () => {
       new model.NodeLabel("l2", "Movie"),
       new model.NodeLabel("l3", "Genre"),
     ];
-    const schema = new model.GraphSchemaRepresentation(
-      "1.0.0",
-      new model.GraphSchema(labels, [], [], [])
-    );
+    const schema = new model.GraphSchema(labels, [], [], []);
+
     const tokens = schema.getAllNodeLabelTokens();
     expect(tokens).toMatchInlineSnapshot(`
       [
@@ -245,10 +243,7 @@ describe("Programatic model tests", () => {
       new model.RelationshipType("rt2", "DIRECTED"),
       new model.RelationshipType("rt3", "IS_GENRE"),
     ];
-    const schema = new model.GraphSchemaRepresentation(
-      "1.0.0",
-      new model.GraphSchema([], relationshipTypes, [], [])
-    );
+    const schema = new model.GraphSchema([], relationshipTypes, [], []);
     const tokens = schema.getAllRelationshipTypeTokens();
     expect(tokens).toMatchInlineSnapshot(`
       [
@@ -297,14 +292,11 @@ describe("Programatic model tests", () => {
       ),
     ];
 
-    const schema = new model.GraphSchemaRepresentation(
-      "1.0.0",
-      new model.GraphSchema(
-        labels,
-        relationshipTypes,
-        nodeObjectTypes,
-        relationshipObjectTypes
-      )
+    const schema = new model.GraphSchema(
+      labels,
+      relationshipTypes,
+      nodeObjectTypes,
+      relationshipObjectTypes
     );
     const tokens = schema.getAllPropertyTokens();
     expect(tokens).toMatchInlineSnapshot(`

--- a/packages/graph-schema-utils/test/model/programatical.test.ts
+++ b/packages/graph-schema-utils/test/model/programatical.test.ts
@@ -267,11 +267,12 @@ describe("Programatic model tests", () => {
     ];
     const relationshipTypes = [new model.RelationshipType("rt1", "ACTED_IN")];
     const properties = [
-      new model.Property("name", new model.PropertyBaseType("string")),
-      new model.Property("name", new model.PropertyBaseType("string")),
+      new model.Property("name", new model.PropertyBaseType("string"), false),
+      new model.Property("name", new model.PropertyBaseType("string"), false),
       new model.Property(
         "roles",
-        new model.PropertyArrayType(new model.PropertyBaseType("string"))
+        new model.PropertyArrayType(new model.PropertyBaseType("string")),
+        false
       ),
     ];
     const nodeObjectTypes = [

--- a/packages/graph-schema-utils/test/model/programatical.test.ts
+++ b/packages/graph-schema-utils/test/model/programatical.test.ts
@@ -218,4 +218,99 @@ describe("Programatic model tests", () => {
       ]
     `);
   });
+  test("getAllLabelTokes returns all label tokens", () => {
+    // call getAllLabelTokens on a graph schema with 3 labels
+    const labels = [
+      new model.NodeLabel("l1", "Person"),
+      new model.NodeLabel("l2", "Movie"),
+      new model.NodeLabel("l3", "Genre"),
+    ];
+    const schema = new model.GraphSchemaRepresentation(
+      "1.0.0",
+      new model.GraphSchema(labels, [], [], [])
+    );
+    const tokens = schema.getAllNodeLabelTokens();
+    expect(tokens).toMatchInlineSnapshot(`
+      [
+        "Person",
+        "Movie",
+        "Genre",
+      ]
+    `);
+  });
+  test("getAllRelationshipTypeTokens returns all relationship type tokens", () => {
+    // call getAllRelationshipTypeTokens on a graph schema with 3 relationship types
+    const relationshipTypes = [
+      new model.RelationshipType("rt1", "ACTED_IN"),
+      new model.RelationshipType("rt2", "DIRECTED"),
+      new model.RelationshipType("rt3", "IS_GENRE"),
+    ];
+    const schema = new model.GraphSchemaRepresentation(
+      "1.0.0",
+      new model.GraphSchema([], relationshipTypes, [], [])
+    );
+    const tokens = schema.getAllRelationshipTypeTokens();
+    expect(tokens).toMatchInlineSnapshot(`
+      [
+        "ACTED_IN",
+        "DIRECTED",
+        "IS_GENRE",
+      ]
+    `);
+  });
+  test("getAllPropertyTokens returns all unique property tokens", () => {
+    // call getAllPropertyTokens on a graph schema with 3 node object types and 3 relationship object types
+    const labels = [
+      new model.NodeLabel("l1", "Person"),
+      new model.NodeLabel("l2", "Dog"),
+      new model.NodeLabel("l3", "Movie"),
+    ];
+    const relationshipTypes = [new model.RelationshipType("rt1", "ACTED_IN")];
+    const properties = [
+      new model.Property("name", new model.PropertyBaseType("string")),
+      new model.Property("name", new model.PropertyBaseType("string")),
+      new model.Property(
+        "roles",
+        new model.PropertyArrayType(new model.PropertyBaseType("string"))
+      ),
+    ];
+    const nodeObjectTypes = [
+      new model.NodeObjectType("n1", [labels[0]], [properties[0]]),
+      new model.NodeObjectType("n2", [labels[1]], [properties[1]]),
+      new model.NodeObjectType("n3", [labels[2]]),
+    ];
+
+    const relationshipObjectTypes = [
+      new model.RelationshipObjectType(
+        "r1",
+        relationshipTypes[0],
+        nodeObjectTypes[0],
+        nodeObjectTypes[2],
+        [properties[2]]
+      ),
+      new model.RelationshipObjectType(
+        "r2",
+        relationshipTypes[0],
+        nodeObjectTypes[1],
+        nodeObjectTypes[2]
+      ),
+    ];
+
+    const schema = new model.GraphSchemaRepresentation(
+      "1.0.0",
+      new model.GraphSchema(
+        labels,
+        relationshipTypes,
+        nodeObjectTypes,
+        relationshipObjectTypes
+      )
+    );
+    const tokens = schema.getAllPropertyTokens();
+    expect(tokens).toMatchInlineSnapshot(`
+      [
+        "name",
+        "roles",
+      ]
+    `);
+  });
 });


### PR DESCRIPTION
Reduces boilerplate when the structure isn't important.

```js
graphSchema.getAllNodeLabelTokens()
graphSchema.getAllRelationshipTypeTokens()
graphSchema.getAllPropertyTokens()
```