### PR TITLE
Add script to run TS checks - activate it where tests run

### DIFF
--- a/.changeset/gentle-mice-battle.md
+++ b/.changeset/gentle-mice-battle.md
@@ -1,0 +1,6 @@
+---
+"@neo4j/graph-schema-utils": patch
+"@neo4j/graph-json-schema": patch
+---
+
+Add GHA to run TS checks (incl. test files) in addition to tests and builds

--- a/.github/workflows/pr-and-push-tests.yml
+++ b/.github/workflows/pr-and-push-tests.yml
@@ -23,6 +23,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install deps
       run: npm ci
+    - name: Run TS checks
+      run: npm run check
     - name: Run tests
       run: npm run test
     - name: Run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -4446,20 +4446,20 @@
     },
     "packages/graph-schema-utils": {
       "name": "@neo4j/graph-schema-utils",
-      "version": "1.0.0-next.1",
+      "version": "1.0.0-next.6",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0"
       },
       "devDependencies": {
-        "@neo4j/graph-json-schema": "*",
+        "@neo4j/graph-json-schema": "1.0.0-next.2",
         "@vitest/coverage-c8": "^0.25.3",
         "vitest": "^0.25.3"
       }
     },
     "packages/json-schema": {
       "name": "@neo4j/graph-json-schema",
-      "version": "1.0.0",
+      "version": "1.0.0-next.2",
       "license": "Apache-2.0"
     }
   },
@@ -5060,7 +5060,7 @@
     "@neo4j/graph-schema-utils": {
       "version": "file:packages/graph-schema-utils",
       "requires": {
-        "@neo4j/graph-json-schema": "*",
+        "@neo4j/graph-json-schema": "1.0.0-next.2",
         "@vitest/coverage-c8": "^0.25.3",
         "ajv": "^8.11.0",
         "vitest": "^0.25.3"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Monorepo for Graph Schema JSON Utils",
   "scripts": {
     "test": "npm run test --workspaces",
+    "check": "npm run check --workspaces",
     "build": "npm run build --workspaces",
     "changeset": "changeset"
   },

--- a/packages/graph-schema-utils/package.json
+++ b/packages/graph-schema-utils/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "test:watch": "vitest",
     "test": "vitest run",
-    "build": "tsc"
+    "build": "tsc --project tsconfig.build.json",
+    "check": "tsc --project tsconfig.check.json"
   },
   "files": [
     "dist"

--- a/packages/graph-schema-utils/test/model/serialize.test.ts
+++ b/packages/graph-schema-utils/test/model/serialize.test.ts
@@ -30,7 +30,6 @@ describe("Serializer tests", () => {
 
   test("Throws if label refs aren't connected", () => {
     const parsed = model.GraphSchemaRepresentation.parseJson(fullSchema);
-    // @ts-expect-error - we want to test this
     parsed.graphSchema.nodeObjectTypes[0].labels[0] = undefined;
     assert.throws(
       () => parsed.toJson(),
@@ -40,7 +39,6 @@ describe("Serializer tests", () => {
 
   test("Throws if type ref aren't connected", () => {
     const parsed = model.GraphSchemaRepresentation.parseJson(fullSchema);
-    // @ts-expect-error - we want to test this
     parsed.graphSchema.relationshipObjectTypes[0].type = undefined;
     assert.throws(
       () => parsed.toJson(),
@@ -50,7 +48,6 @@ describe("Serializer tests", () => {
 
   test("Throws if from ref aren't connected", () => {
     const parsed = model.GraphSchemaRepresentation.parseJson(fullSchema);
-    // @ts-expect-error - we want to test this
     parsed.graphSchema.relationshipObjectTypes[0].from = undefined;
     assert.throws(
       () => parsed.toJson(),
@@ -60,7 +57,6 @@ describe("Serializer tests", () => {
 
   test("Throws if to ref aren't connected", () => {
     const parsed = model.GraphSchemaRepresentation.parseJson(fullSchema);
-    // @ts-expect-error - we want to test this
     parsed.graphSchema.relationshipObjectTypes[0].to = undefined;
     assert.throws(
       () => parsed.toJson(),

--- a/packages/graph-schema-utils/test/validation/error-validation.test.ts
+++ b/packages/graph-schema-utils/test/validation/error-validation.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import path from "path";
-import { SchemaValidationError, validateSchema } from "../../src/index";
+import { SchemaValidationError, validateSchema } from "../../src/index.js";
 import { readFile } from "../fs.utils.js";
 import { describe, test } from "vitest";
 import { createRequire } from "module";
@@ -58,7 +58,6 @@ describe("Validate type errors", () => {
       allErrors = e.messages;
     }
     assert.equal(allErrors.length, NUM_ADDITIONAL_FIELDS_GRAPH_SCHEMA);
-    // @ts-expect-error
     assert.equal(allErrors[0].keyword, "additionalProperties");
 
     //------------
@@ -85,7 +84,6 @@ describe("Validate type errors", () => {
       NUM_ADDITIONAL_NODELABEL_ROOT
     );
     assert.equal(
-      // @ts-expect-error
       allErrorsAddittionalNodeLabelsRoot[0].keyword,
       "additionalProperties"
     );
@@ -113,7 +111,6 @@ describe("Validate type errors", () => {
       NUM_ADDITIONAL_RELATIONSHIP_TYPES_ROOT
     );
     assert.equal(
-      // @ts-expect-error
       allErrorsAddittionalRelationshipTypeRoot[0].keyword,
       "additionalProperties"
     );
@@ -141,7 +138,6 @@ describe("Validate type errors", () => {
       NUM_ADDITIONAL_NODESPEC_ROOT
     );
     assert.equal(
-      // @ts-expect-error
       allErrorsAddittionalNodeSpecsRoot[0].keyword,
       "additionalProperties"
     );
@@ -168,7 +164,6 @@ describe("Validate type errors", () => {
       NUM_ADDITIONAL_NODESPECS_PROPERTIRES
     );
     assert.equal(
-      // @ts-expect-error
       allErrorsAddittionalNodeSpecsProperties[0].keyword,
       "additionalProperties"
     );
@@ -195,7 +190,6 @@ describe("Validate type errors", () => {
       NUM_ADDITIONAL_NODESPEC_LABELS
     );
     assert.equal(
-      // @ts-expect-error
       allErrorsAddittionalNodeSpecsLabels[0].keyword,
       "additionalProperties"
     );
@@ -223,7 +217,6 @@ describe("Validate type errors", () => {
       NUM_ADDITIONAL_RELATIONSHIP_SPECS_TYPE
     );
     assert.equal(
-      // @ts-expect-error
       allErrorsAddittionalRelationshipSpecsType[0].keyword,
       "additionalProperties"
     );
@@ -250,7 +243,6 @@ describe("Validate type errors", () => {
       NUM_ADDITIONAL_RELATIONSHIP_SPECS_PROPERTIES
     );
     assert.equal(
-      // @ts-expect-error
       allErrorsAddittionalRelationshipSpecsProperties[0].keyword,
       "additionalProperties"
     );
@@ -277,7 +269,6 @@ describe("Validate type errors", () => {
       NUM_ADDITIONAL_RELATIONSHIP_SPECS_ROOT
     );
     assert.equal(
-      // @ts-expect-error
       allErrorsAddittionalRelationshipSpecsRoot[0].keyword,
       "additionalProperties"
     );

--- a/packages/graph-schema-utils/test/validation/full.test.ts
+++ b/packages/graph-schema-utils/test/validation/full.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import path from "path";
-import { validateSchema } from "../../src/index";
+import { validateSchema } from "../../src/index.js";
 import { readFile } from "../fs.utils.js";
 import { describe, test } from "vitest";
 import { createRequire } from "module";

--- a/packages/graph-schema-utils/test/validation/new-props.test.ts
+++ b/packages/graph-schema-utils/test/validation/new-props.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import path from "path";
-import { validateSchema } from "../../src/index";
+import { validateSchema } from "../../src/index.js";
 import { readFile } from "../fs.utils.js";
 import { describe, test } from "vitest";
 import { createRequire } from "module";

--- a/packages/graph-schema-utils/test/validation/root-schema.test.ts
+++ b/packages/graph-schema-utils/test/validation/root-schema.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import path from "path";
-import { validateSchema } from "../../src/index";
+import { validateSchema } from "../../src/index.js";
 import { readFile } from "../fs.utils.js";
 import { describe, test } from "vitest";
 import { createRequire } from "module";

--- a/packages/graph-schema-utils/test/validation/simple.test.ts
+++ b/packages/graph-schema-utils/test/validation/simple.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from "node:assert";
 import { fileURLToPath } from "url";
 import path from "path";
-import { validateSchema } from "../../src/index";
+import { validateSchema } from "../../src/index.js";
 import { readFile } from "../fs.utils.js";
 import { describe, test } from "vitest";
 import { createRequire } from "module";

--- a/packages/graph-schema-utils/test/validation/validation.test.ts
+++ b/packages/graph-schema-utils/test/validation/validation.test.ts
@@ -1,9 +1,9 @@
 import { strict as assert } from "node:assert";
 import path from "path";
-import { validateSchema } from "../../src/index";
+import { validateSchema } from "../../src/index.js";
 import { readFile } from "../fs.utils.js";
 import { describe, test } from "vitest";
-import { InputTypeError } from "../../src/validation";
+import { InputTypeError } from "../../src/validation.js";
 import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);

--- a/packages/graph-schema-utils/tsconfig.build.json
+++ b/packages/graph-schema-utils/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"]
+}

--- a/packages/graph-schema-utils/tsconfig.check.json
+++ b/packages/graph-schema-utils/tsconfig.check.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/packages/graph-schema-utils/tsconfig.json
+++ b/packages/graph-schema-utils/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "ES2020",
     "sourceMap": true,
     "outDir": "dist",
-    "declaration": true
-  },
-  "include": ["src/**/*"]
+    "declaration": true,
+    "skipLibCheck": true
+  }
 }

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "scripts": {
     "test": "exit 0",
+    "check": "exit 0",
     "build": "exit 0"
   },
   "files": [


### PR DESCRIPTION
Split ts configs into two files to make sure we don't ship compiled test files