### PR TITLE
Add GraphSchemaRep json struct type & parse function

### DIFF
--- a/.changeset/brave-rivers-dream.md
+++ b/.changeset/brave-rivers-dream.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graph-schema-utils": patch
+---
+
+Add json struct helpers

--- a/packages/graph-schema-utils/src/model/index.ts
+++ b/packages/graph-schema-utils/src/model/index.ts
@@ -20,8 +20,14 @@ export class GraphSchemaRepresentation {
     };
   }
 
-  static parseJson(jsonString) {
+  static parseJson(jsonString: string) {
     const json = JSON.parse(jsonString);
+    return this.parseJsonStruct(json);
+  }
+
+  static parseJsonStruct(json: {
+    graphSchemaRepresentation: GraphSchemaRepresentationJsonStruct;
+  }) {
     const version = json.graphSchemaRepresentation.version;
     const graphSchema = GraphSchema.fromJsonStruct(
       json.graphSchemaRepresentation.graphSchema
@@ -29,6 +35,46 @@ export class GraphSchemaRepresentation {
     return new GraphSchemaRepresentation(version, graphSchema);
   }
 }
+
+export type GraphSchemaRepresentationJsonStruct = {
+  version: string;
+  graphSchema: {
+    nodeLabels: { $id: string; token: string }[];
+    relationshipTypes: { $id: string; token: string }[];
+    nodeObjectTypes: {
+      $id: string;
+      labels: { $ref: string }[];
+      properties: {
+        token: string;
+        type:
+          | { type: PrimitivePropertyTypes }
+          | { type: "array"; items: { type: PrimitivePropertyTypes } }
+          | (
+              | { type: PrimitivePropertyTypes }
+              | { type: "array"; items: { type: PrimitivePropertyTypes } }
+            )[];
+        nullable: boolean;
+      }[];
+      relationshipObjectTypes: {
+        $id: string;
+        type: { $ref: string };
+        from: { $ref: string };
+        to: { $ref: string };
+        properties: {
+          token: string;
+          type:
+            | { type: string }
+            | { type: "array"; items: { type: "string" } }
+            | (
+                | { type: string }
+                | { type: "array"; items: { type: "string" } }
+              )[];
+          nullable: boolean;
+        }[];
+      }[];
+    }[];
+  };
+};
 
 export class GraphSchema {
   nodeLabels: NodeLabel[];

--- a/packages/graph-schema-utils/test/model/parse.test.ts
+++ b/packages/graph-schema-utils/test/model/parse.test.ts
@@ -89,7 +89,7 @@ describe("Parser tests", () => {
     schema.graphSchemaRepresentation.graphSchema.nodeObjectTypes[0].labels[0].$ref =
       "NON_EXISTING_LABEL";
     assert.throws(() => {
-      model.GraphSchemaRepresentation.parseJson(JSON.stringify(schema));
+      model.GraphSchemaRepresentation.parseJsonStruct(schema);
     }, new Error("Not all label references are defined"));
   });
   test("throws if type referece is not found", () => {
@@ -97,7 +97,7 @@ describe("Parser tests", () => {
     schema.graphSchemaRepresentation.graphSchema.relationshipObjectTypes[0].type.$ref =
       "NON_EXISTING_TYPE";
     assert.throws(() => {
-      model.GraphSchemaRepresentation.parseJson(JSON.stringify(schema));
+      model.GraphSchemaRepresentation.parseJsonStruct(schema);
     }, new Error("Not all relationship type references are defined"));
   });
   test("throws if from referece is not found", () => {
@@ -105,7 +105,7 @@ describe("Parser tests", () => {
     schema.graphSchemaRepresentation.graphSchema.relationshipObjectTypes[0].from.$ref =
       "NON_EXISTING_NODE";
     assert.throws(() => {
-      model.GraphSchemaRepresentation.parseJson(JSON.stringify(schema));
+      model.GraphSchemaRepresentation.parseJsonStruct(schema);
     }, new Error("Not all node object type references in from are defined"));
   });
   test("throws if to referece is not found", () => {
@@ -113,7 +113,7 @@ describe("Parser tests", () => {
     schema.graphSchemaRepresentation.graphSchema.relationshipObjectTypes[0].to.$ref =
       "NON_EXISTING_NODE";
     assert.throws(() => {
-      model.GraphSchemaRepresentation.parseJson(JSON.stringify(schema));
+      model.GraphSchemaRepresentation.parseJsonStruct(schema);
     }, new Error("Not all node object type references in to are defined"));
   });
 });

--- a/packages/graph-schema-utils/test/model/serialize.test.ts
+++ b/packages/graph-schema-utils/test/model/serialize.test.ts
@@ -29,9 +29,11 @@ describe("Serializer tests", () => {
   });
 
   test("Can parse a graph schema and serialize it to be the same json struct", () => {
-    const parsed = model.GraphSchemaRepresentation.parseJson(fullSchema);
+    const fullSchemaJsonStruct = JSON.parse(fullSchema);
+    const parsed =
+      model.GraphSchemaRepresentation.parseJsonStruct(fullSchemaJsonStruct);
     const serializedStruct = parsed.toJsonStruct();
-    assert.deepEqual(serializedStruct, JSON.parse(fullSchema));
+    assert.deepEqual(serializedStruct, fullSchemaJsonStruct);
   });
 
   test("Throws if label refs aren't connected", () => {


### PR DESCRIPTION
- Add a `GraphSchemaRepresentation.parseJsonStruct` function
- Add a `GraphSchemaRepresentationJsonStruct` type to represent the json schema object