### PR TITLE
keep order of all except node labels and rel types

### DIFF
--- a/.changeset/tasty-actors-repeat.md
+++ b/.changeset/tasty-actors-repeat.md
@@ -1,0 +1,6 @@
+---
+"@neo4j/graph-schema-utils": patch
+"@neo4j/graph-introspection": patch
+---
+
+keep order except for node labels and rel types

--- a/packages/graph-schema-utils/src/formatters/json/__snapshots__/serialized-full.json
+++ b/packages/graph-schema-utils/src/formatters/json/__snapshots__/serialized-full.json
@@ -43,16 +43,6 @@
           ],
           "properties": [
             {
-              "token": "born",
-              "type": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "nullable": false
-            },
-            {
               "token": "id",
               "type": [
                 {
@@ -68,6 +58,16 @@
                   "type": "string"
                 }
               ],
+              "nullable": false
+            },
+            {
+              "token": "born",
+              "type": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "nullable": false
             },
             {

--- a/packages/graph-schema-utils/src/formatters/json/extensions.ts
+++ b/packages/graph-schema-utils/src/formatters/json/extensions.ts
@@ -33,12 +33,10 @@ export function toJson(
   const relationshipTypes = schema.relationshipTypes
     .sort((a, b) => (a.$id < b.$id ? -1 : 1))
     .map(relationshipType.extract);
-  const nodeObjectTypes = schema.nodeObjectTypes
-    .sort((a, b) => (a.$id < b.$id ? -1 : 1))
-    .map(nodeObjectType.extract);
-  const relationshipObjectTypes = schema.relationshipObjectTypes
-    .sort((a, b) => (a.$id < b.$id ? -1 : 1))
-    .map(relationshipObjectType.extract);
+  const nodeObjectTypes = schema.nodeObjectTypes.map(nodeObjectType.extract);
+  const relationshipObjectTypes = schema.relationshipObjectTypes.map(
+    relationshipObjectType.extract
+  );
   const out: RootSchemaJsonStruct = {
     graphSchemaRepresentation: {
       version: VERSION,
@@ -193,9 +191,7 @@ const nodeObjectType = {
   extract: (nodeObjectType: NodeObjectType): NodeObjectTypeJsonStruct => ({
     $id: nodeObjectType.$id,
     labels: nodeObjectType.labels.map(nodeLabel.toRef),
-    properties: nodeObjectType.properties
-      .sort((a, b) => (a.token < b.token ? -1 : 1))
-      .map(property.extract),
+    properties: nodeObjectType.properties.map(property.extract),
   }),
   create: (
     nodeObjectType: NodeObjectTypeJsonStruct,
@@ -225,9 +221,7 @@ const relationshipObjectType = {
     type: relationshipType.toRef(relationshipObjectType.type),
     from: nodeObjectType.toRef(relationshipObjectType.from),
     to: nodeObjectType.toRef(relationshipObjectType.to),
-    properties: relationshipObjectType.properties
-      .sort((a, b) => (a.token < b.token ? -1 : 1))
-      .map(property.extract),
+    properties: relationshipObjectType.properties.map(property.extract),
   }),
   create: (
     relationshipObjectType: RelationshipObjectTypeJsonStruct,

--- a/packages/graph-schema-utils/src/formatters/json/test-schemas/full.json
+++ b/packages/graph-schema-utils/src/formatters/json/test-schemas/full.json
@@ -43,16 +43,6 @@
           ],
           "properties": [
             {
-              "token": "born",
-              "type": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "nullable": false
-            },
-            {
               "token": "id",
               "type": [
                 {
@@ -68,6 +58,16 @@
                   "type": "string"
                 }
               ],
+              "nullable": false
+            },
+            {
+              "token": "born",
+              "type": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "nullable": false
             },
             {

--- a/packages/introspection/src/__snapshots__/matrix.json
+++ b/packages/introspection/src/__snapshots__/matrix.json
@@ -48,9 +48,9 @@
           ],
           "properties": [
             {
-              "token": "released",
+              "token": "title",
               "type": {
-                "type": "integer"
+                "type": "string"
               },
               "nullable": false
             },
@@ -62,9 +62,9 @@
               "nullable": true
             },
             {
-              "token": "title",
+              "token": "released",
               "type": {
-                "type": "string"
+                "type": "integer"
               },
               "nullable": false
             }
@@ -79,18 +79,18 @@
           ],
           "properties": [
             {
-              "token": "born",
-              "type": {
-                "type": "integer"
-              },
-              "nullable": true
-            },
-            {
               "token": "name",
               "type": {
                 "type": "string"
               },
               "nullable": false
+            },
+            {
+              "token": "born",
+              "type": {
+                "type": "integer"
+              },
+              "nullable": true
             }
           ]
         }
@@ -172,16 +172,16 @@
           },
           "properties": [
             {
-              "token": "rating",
+              "token": "summary",
               "type": {
-                "type": "integer"
+                "type": "string"
               },
               "nullable": false
             },
             {
-              "token": "summary",
+              "token": "rating",
               "type": {
-                "type": "string"
+                "type": "integer"
               },
               "nullable": false
             }

--- a/packages/introspection/src/__snapshots__/special-chars-nodes.json
+++ b/packages/introspection/src/__snapshots__/special-chars-nodes.json
@@ -19,6 +19,23 @@
       "relationshipTypes": [],
       "nodeObjectTypes": [
         {
+          "$id": "n:Spec`ial",
+          "labels": [
+            {
+              "$ref": "#Spec`ial"
+            }
+          ],
+          "properties": [
+            {
+              "token": "na`me",
+              "type": {
+                "type": "string"
+              },
+              "nullable": false
+            }
+          ]
+        },
+        {
           "$id": "n:Label-1:Label-2",
           "labels": [
             {
@@ -36,23 +53,6 @@
                 "items": {
                   "type": "integer"
                 }
-              },
-              "nullable": false
-            }
-          ]
-        },
-        {
-          "$id": "n:Spec`ial",
-          "labels": [
-            {
-              "$ref": "#Spec`ial"
-            }
-          ],
-          "properties": [
-            {
-              "token": "na`me",
-              "type": {
-                "type": "string"
               },
               "nullable": false
             }

--- a/packages/introspection/src/__snapshots__/standalone-nodes.json
+++ b/packages/introspection/src/__snapshots__/standalone-nodes.json
@@ -19,23 +19,6 @@
       "relationshipTypes": [],
       "nodeObjectTypes": [
         {
-          "$id": "n:Genre",
-          "labels": [
-            {
-              "$ref": "#Genre"
-            }
-          ],
-          "properties": [
-            {
-              "token": "name",
-              "type": {
-                "type": "string"
-              },
-              "nullable": false
-            }
-          ]
-        },
-        {
           "$id": "n:Movie",
           "labels": [
             {
@@ -45,6 +28,23 @@
           "properties": [
             {
               "token": "title",
+              "type": {
+                "type": "string"
+              },
+              "nullable": false
+            }
+          ]
+        },
+        {
+          "$id": "n:Genre",
+          "labels": [
+            {
+              "$ref": "#Genre"
+            }
+          ],
+          "properties": [
+            {
+              "token": "name",
               "type": {
                 "type": "string"
               },


### PR DESCRIPTION
...since the order of those are lost anyway when going from json to class and back.

Keeping of order for those we can since there are use cases where one want to display it in the order it was created. Sorting can easily be done when using the schema but we cannot get the order back.