### PR TITLE
Fix types export from schema utils formatters

### DIFF
--- a/.changeset/lazy-days-design.md
+++ b/.changeset/lazy-days-design.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graph-schema-utils": patch
+---
+
+Fix types export

--- a/packages/graph-schema-utils/package.json
+++ b/packages/graph-schema-utils/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0-next.12",
   "description": "Utilities for Neo4j Graph Schema JSON representation",
   "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/graph-schema-utils/src/formatters/index.ts
+++ b/packages/graph-schema-utils/src/formatters/index.ts
@@ -1,0 +1,1 @@
+export * as json from "./json/index.js";

--- a/packages/graph-schema-utils/src/formatters/json/index.ts
+++ b/packages/graph-schema-utils/src/formatters/json/index.ts
@@ -1,4 +1,4 @@
-export * from "./types.js";
+import * as types from "./types.js";
 export {
   toJson,
   fromJson,
@@ -6,3 +6,5 @@ export {
   toJsonStruct,
   VERSION,
 } from "./extensions.js";
+
+export { types };

--- a/packages/graph-schema-utils/src/index.ts
+++ b/packages/graph-schema-utils/src/index.ts
@@ -1,6 +1,5 @@
 export { validateSchema, SchemaValidationError } from "./validation.js";
 import * as model from "./model/index.js";
-import * as json from "./formatters/json/index.js";
+import * as formatters from "./formatters/index.js";
 
-const formatters = { json };
 export { model, formatters };

--- a/packages/graph-schema-utils/tsconfig.json
+++ b/packages/graph-schema-utils/tsconfig.json
@@ -6,6 +6,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "declaration": true,
+    "declarationDir": "dist/types",
     "skipLibCheck": true,
     "strict": true,
     "resolveJsonModule": true


### PR DESCRIPTION
- Move all generated types to `dist/types` folder
- Add directory layer for `src/formatters`
- Import + Export types to get TS to generate proper d.ts file

After this the types should be available via

```ts
import { formatters } from '@neo4j/graph-schema-utils'

const x: formatters.json.types.GraphSchemaJsonStruct = ...
```