### PR TITLE
only allow list one level deep of property type

### DIFF
--- a/.changeset/fluffy-spoons-camp.md
+++ b/.changeset/fluffy-spoons-camp.md
@@ -1,0 +1,6 @@
+---
+"@neo4j/graph-schema-utils": patch
+"@neo4j/graph-introspection": patch
+---
+
+removed recursive property type

--- a/packages/graph-schema-utils/src/formatters/json/extensions.ts
+++ b/packages/graph-schema-utils/src/formatters/json/extensions.ts
@@ -6,8 +6,8 @@ import {
   NodeLabelIndex,
   NodeObjectType,
   Property,
-  PropertyArrayType,
-  PropertyBaseType,
+  PrimitiveArrayPropertyType,
+  PrimitivePropertyType,
   PropertyType,
   RelationshipObjectType,
   RelationshipType,
@@ -18,23 +18,21 @@ import {
   isNodeLabelIndex,
   isRelationshipTypeConstraint,
   isRelationshipTypeIndex,
-  isPropertyTypeList,
-  isPropertyBaseType,
-  isPropertyArrayType,
+  isPrimitivePropertyType,
+  isPrimitiveArrayPropertyType,
 } from "../../model/index.js";
 import {
   ConstraintJsonStruct,
   IndexJsonStruct,
-  isPrimitivePropertyTypesArrayTypeJsonStruct,
-  isPrimitivePropertyTypesTypeJsonStruct,
-  isPropertyTypeListJsonStruct,
+  isPrimitiveArrayPropertyTypeJsonStruct,
+  isPrimitivePropertyTypeJsonStruct,
   LookupIndexJsonStruct,
   NodeLabelConstraintJsonStruct,
   NodeLabelIndexJsonStruct,
   NodeLabelJsonStruct,
   NodeObjectTypeJsonStruct,
-  PrimitivePropertyTypesArrayType,
-  PrimitivePropertyTypesType,
+  PrimitiveArrayPropertyTypeJsonStruct,
+  PrimitivePropertyTypeJsonStruct,
   PropertyJsonStruct,
   PropertyTypeJsonStruct,
   RelationshipObjectTypeJsonStruct,
@@ -476,36 +474,40 @@ const property = {
 };
 
 const propertyType = {
-  extract: (pt: PropertyType): PropertyTypeJsonStruct => {
-    if (isPropertyTypeList(pt)) {
+  extract: (
+    pt: PropertyType | PropertyType[]
+  ): PropertyTypeJsonStruct | PropertyTypeJsonStruct[] => {
+    if (Array.isArray(pt)) {
       return pt.map((p) => {
-        if (isPropertyBaseType(p)) {
+        if (isPrimitivePropertyType(p)) {
           return propertyBaseType.extract(p);
-        } else if (isPropertyArrayType(p)) {
+        } else if (isPrimitiveArrayPropertyType(p)) {
           return propertyArrayType.extract(p);
         }
         throw Error(`Unknown property type in list ${p}`);
       });
     }
-    if (isPropertyBaseType(pt)) {
+    if (isPrimitivePropertyType(pt)) {
       return propertyBaseType.extract(pt);
-    } else if (isPropertyArrayType(pt)) {
+    } else if (isPrimitiveArrayPropertyType(pt)) {
       return propertyArrayType.extract(pt);
     }
     throw new Error(`Unknown property type ${pt}`);
   },
-  create: (propertyTypeJson: PropertyTypeJsonStruct): PropertyType => {
-    if (isPropertyTypeListJsonStruct(propertyTypeJson)) {
+  create: (
+    propertyTypeJson: PropertyTypeJsonStruct | PropertyTypeJsonStruct[]
+  ): PropertyType | PropertyType[] => {
+    if (Array.isArray(propertyTypeJson)) {
       return propertyTypeJson.map((pt) => {
-        if (isPrimitivePropertyTypesTypeJsonStruct(pt)) {
+        if (isPrimitivePropertyTypeJsonStruct(pt)) {
           return propertyBaseType.create(pt);
-        } else if (isPrimitivePropertyTypesArrayTypeJsonStruct(pt)) {
+        } else if (isPrimitiveArrayPropertyTypeJsonStruct(pt)) {
           return propertyArrayType.create(pt.items.type);
         }
         throw new Error(`Unknown property type in list ${pt}`);
       });
     }
-    if (isPrimitivePropertyTypesArrayTypeJsonStruct(propertyTypeJson)) {
+    if (isPrimitiveArrayPropertyTypeJsonStruct(propertyTypeJson)) {
       return propertyArrayType.create(propertyTypeJson.items.type);
     }
     return propertyBaseType.create(propertyTypeJson);
@@ -514,23 +516,23 @@ const propertyType = {
 
 const propertyBaseType = {
   extract: (
-    propertyBaseType: PropertyBaseType
-  ): PrimitivePropertyTypesType => ({
+    propertyBaseType: PrimitivePropertyType
+  ): PrimitivePropertyTypeJsonStruct => ({
     type: propertyBaseType.type,
   }),
-  create: (btype: PrimitivePropertyTypesType) =>
-    new PropertyBaseType(btype.type),
+  create: (btype: PrimitivePropertyTypeJsonStruct) =>
+    new PrimitivePropertyType(btype.type),
 };
 
 const propertyArrayType = {
   extract: (
-    propertyArrayType: PropertyArrayType
-  ): PrimitivePropertyTypesArrayType => ({
+    propertyArrayType: PrimitiveArrayPropertyType
+  ): PrimitiveArrayPropertyTypeJsonStruct => ({
     type: "array",
     items: propertyBaseType.extract(propertyArrayType.items),
   }),
-  create: (type: PrimitivePropertyTypesArrayType["items"]["type"]) =>
-    new PropertyArrayType(propertyBaseType.create({ type })),
+  create: (type: PrimitiveArrayPropertyTypeJsonStruct["items"]["type"]) =>
+    new PrimitiveArrayPropertyType(propertyBaseType.create({ type })),
 };
 
 const nodeObjectType = {

--- a/packages/graph-schema-utils/src/formatters/json/parse.test.ts
+++ b/packages/graph-schema-utils/src/formatters/json/parse.test.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { readFile } from "../../../test/fs.utils.js";
 import { describe, test } from "vitest";
 import { fromJson } from "./index.js";
-import { PropertyTypes } from "../../model/index.js";
+import { PropertyArrayType, PropertyBaseType } from "../../model/index.js";
 
 import { validateSchema } from "../../validation.js";
 
@@ -66,7 +66,11 @@ describe("Parser tests", () => {
       "roles"
     );
     assert.strictEqual(
-      (parsed.relationshipTypes[0].properties[0].type as PropertyTypes).type,
+      (
+        parsed.relationshipTypes[0].properties[0].type as
+          | PropertyBaseType
+          | PropertyArrayType
+      ).type,
       "array"
     );
   });

--- a/packages/graph-schema-utils/src/formatters/json/parse.test.ts
+++ b/packages/graph-schema-utils/src/formatters/json/parse.test.ts
@@ -3,7 +3,10 @@ import path from "path";
 import { readFile } from "../../../test/fs.utils.js";
 import { describe, test } from "vitest";
 import { fromJson } from "./index.js";
-import { PropertyArrayType, PropertyBaseType } from "../../model/index.js";
+import {
+  PrimitiveArrayPropertyType,
+  PrimitivePropertyType,
+} from "../../model/index.js";
 
 import { validateSchema } from "../../validation.js";
 
@@ -68,8 +71,8 @@ describe("Parser tests", () => {
     assert.strictEqual(
       (
         parsed.relationshipTypes[0].properties[0].type as
-          | PropertyBaseType
-          | PropertyArrayType
+          | PrimitivePropertyType
+          | PrimitiveArrayPropertyType
       ).type,
       "array"
     );

--- a/packages/graph-schema-utils/src/formatters/json/types.ts
+++ b/packages/graph-schema-utils/src/formatters/json/types.ts
@@ -105,7 +105,7 @@ export type LookupIndexJsonStruct = IndexJsonStruct & {
 export type PropertyJsonStruct = {
   $id: string;
   token: string;
-  type: PropertyTypeJsonStructRecrsive;
+  type: PropertyTypeJsonStruct;
   nullable: boolean;
 };
 
@@ -115,11 +115,27 @@ export type PrimitivePropertyTypesArrayType = {
   items: { type: PrimitivePropertyTypes };
 };
 
+export type PropertyTypeListJsonStruct = (PrimitivePropertyTypesType | PrimitivePropertyTypesArrayType)[]
+
 export type PropertyTypeJsonStruct =
   | PrimitivePropertyTypesArrayType
   | PrimitivePropertyTypesType
-  | (PrimitivePropertyTypesType | PrimitivePropertyTypesArrayType)[];
+  | PropertyTypeListJsonStruct;
 
-export type PropertyTypeJsonStructRecrsive =
-  | PropertyTypeJsonStruct
-  | Array<PropertyTypeJsonStruct | PropertyTypeJsonStructRecrsive[]>;
+export const isPropertyTypeListJsonStruct = (
+  propertyType: PropertyTypeJsonStruct
+): propertyType is PropertyTypeListJsonStruct => {
+  return Array.isArray(propertyType);
+}
+
+export const isPrimitivePropertyTypesTypeJsonStruct = (
+  propertyType: PropertyTypeJsonStruct
+): propertyType is PrimitivePropertyTypesType => {
+  return typeof propertyType === "object" && "type" in propertyType && propertyType.type !== "array";
+}
+
+export const isPrimitivePropertyTypesArrayTypeJsonStruct = (
+  propertyType: PropertyTypeJsonStruct
+): propertyType is PrimitivePropertyTypesArrayType => {
+  return typeof propertyType === "object" && "type" in propertyType && propertyType.type === "array" && propertyType.items !== undefined;
+}

--- a/packages/graph-schema-utils/src/formatters/json/types.ts
+++ b/packages/graph-schema-utils/src/formatters/json/types.ts
@@ -2,6 +2,7 @@ import {
   ConstraintType,
   EntityType,
   IndexType,
+  PRIMITIVE_TYPE_OPTIONS,
   PrimitivePropertyTypes,
 } from "../../model/index.js";
 
@@ -105,37 +106,37 @@ export type LookupIndexJsonStruct = IndexJsonStruct & {
 export type PropertyJsonStruct = {
   $id: string;
   token: string;
-  type: PropertyTypeJsonStruct;
+  type: PropertyTypeJsonStruct | PropertyTypeJsonStruct[];
   nullable: boolean;
 };
 
-export type PrimitivePropertyTypesType = { type: PrimitivePropertyTypes };
-export type PrimitivePropertyTypesArrayType = {
+export type PrimitivePropertyTypeJsonStruct = { type: PrimitivePropertyTypes };
+export type PrimitiveArrayPropertyTypeJsonStruct = {
   type: "array";
   items: { type: PrimitivePropertyTypes };
 };
 
-export type PropertyTypeListJsonStruct = (PrimitivePropertyTypesType | PrimitivePropertyTypesArrayType)[]
-
 export type PropertyTypeJsonStruct =
-  | PrimitivePropertyTypesArrayType
-  | PrimitivePropertyTypesType
-  | PropertyTypeListJsonStruct;
+  | PrimitiveArrayPropertyTypeJsonStruct
+  | PrimitivePropertyTypeJsonStruct;
 
-export const isPropertyTypeListJsonStruct = (
+export const isPrimitivePropertyTypeJsonStruct = (
   propertyType: PropertyTypeJsonStruct
-): propertyType is PropertyTypeListJsonStruct => {
-  return Array.isArray(propertyType);
-}
+): propertyType is PrimitivePropertyTypeJsonStruct => {
+  return (
+    typeof propertyType === "object" &&
+    "type" in propertyType &&
+    PRIMITIVE_TYPE_OPTIONS.some((p) => propertyType.type === p)
+  );
+};
 
-export const isPrimitivePropertyTypesTypeJsonStruct = (
+export const isPrimitiveArrayPropertyTypeJsonStruct = (
   propertyType: PropertyTypeJsonStruct
-): propertyType is PrimitivePropertyTypesType => {
-  return typeof propertyType === "object" && "type" in propertyType && propertyType.type !== "array";
-}
-
-export const isPrimitivePropertyTypesArrayTypeJsonStruct = (
-  propertyType: PropertyTypeJsonStruct
-): propertyType is PrimitivePropertyTypesArrayType => {
-  return typeof propertyType === "object" && "type" in propertyType && propertyType.type === "array" && propertyType.items !== undefined;
-}
+): propertyType is PrimitiveArrayPropertyTypeJsonStruct => {
+  return (
+    typeof propertyType === "object" &&
+    "type" in propertyType &&
+    propertyType.type === "array" &&
+    propertyType.items !== undefined
+  );
+};

--- a/packages/graph-schema-utils/src/formatters/llm-prompt/index.ts
+++ b/packages/graph-schema-utils/src/formatters/llm-prompt/index.ts
@@ -2,8 +2,7 @@ import {
   GraphSchema,
   NodeObjectType,
   PropertyBaseType,
-  PropertyTypeRecursive,
-  PropertyTypes,
+  PropertyType,
   RelationshipObjectType,
 } from "../../model/index.js";
 import { ElementPropertyObject } from "./types.js";
@@ -141,7 +140,7 @@ export function toOskars(schema: GraphSchema): string {
   return out.join("\n");
 }
 
-function formatPropertyType(type: PropertyTypeRecursive): string {
+function formatPropertyType(type: PropertyType): string {
   if (Array.isArray(type)) {
     return type.map(formatPropertyType).join("|");
   }

--- a/packages/graph-schema-utils/src/formatters/llm-prompt/index.ts
+++ b/packages/graph-schema-utils/src/formatters/llm-prompt/index.ts
@@ -1,7 +1,7 @@
 import {
   GraphSchema,
   NodeObjectType,
-  PropertyBaseType,
+  PrimitivePropertyType,
   PropertyType,
   RelationshipObjectType,
 } from "../../model/index.js";
@@ -140,11 +140,11 @@ export function toOskars(schema: GraphSchema): string {
   return out.join("\n");
 }
 
-function formatPropertyType(type: PropertyType): string {
+function formatPropertyType(type: PropertyType | PropertyType[]): string {
   if (Array.isArray(type)) {
     return type.map(formatPropertyType).join("|");
   }
-  if (type instanceof PropertyBaseType) {
+  if (type instanceof PrimitivePropertyType) {
     return type.type;
   }
   return `${type.items.type}[]`;

--- a/packages/graph-schema-utils/src/model/index.ts
+++ b/packages/graph-schema-utils/src/model/index.ts
@@ -295,35 +295,38 @@ export type IndexType =
 
 export type EntityType = "node" | "relationship";
 
-export type PropertyType =
-  | PropertyBaseType
-  | PropertyArrayType
-  | PropertyTypeList;
+export type PropertyType = PrimitivePropertyType | PrimitiveArrayPropertyType;
 
-export type PropertyTypeList = (PropertyBaseType | PropertyArrayType)[];
+export const isPrimitiveArrayPropertyType = (
+  property: PropertyType
+): property is PrimitiveArrayPropertyType => {
+  return (
+    property instanceof Object &&
+    property.type === "array" &&
+    property.items !== undefined
+  );
+};
 
-export const isPropertyBaseType = (p: PropertyType): p is PropertyBaseType => {
-  return p instanceof PropertyBaseType;
-}
-
-export const isPropertyArrayType = (p: PropertyType): p is PropertyArrayType => {
-  return p instanceof PropertyArrayType;
-}
-
-export const isPropertyTypeList = (p: PropertyType): p is PropertyTypeList => {
-  return Array.isArray(p);
-}
+export const isPrimitivePropertyType = (
+  property: PropertyType
+): property is PrimitivePropertyType => {
+  return (
+    property instanceof Object &&
+    "type" in property &&
+    PRIMITIVE_TYPE_OPTIONS.some((p) => property.type === p)
+  );
+};
 
 export class Property {
   $id: string;
   token: string;
-  type: PropertyType;
+  type: PropertyType | PropertyType[];
   nullable: boolean;
 
   constructor(
     $id: string,
     token: string,
-    type: PropertyType,
+    type: PropertyType | PropertyType[],
     nullable: boolean
   ) {
     this.$id = $id;
@@ -333,32 +336,35 @@ export class Property {
   }
 }
 
-export class PropertyBaseType {
+export class PrimitivePropertyType {
   type: PrimitivePropertyTypes;
   constructor(type: PrimitivePropertyTypes) {
     this.type = type;
   }
 }
 
-export class PropertyArrayType {
-  items: PropertyBaseType;
+export class PrimitiveArrayPropertyType {
+  items: PrimitivePropertyType;
   type: "array";
 
-  constructor(items: PropertyBaseType) {
+  constructor(items: PrimitivePropertyType) {
     this.type = "array";
     this.items = items;
   }
 }
 
-export type PrimitivePropertyTypes =
-  | "integer"
-  | "string"
-  | "float"
-  | "boolean"
-  | "point"
-  | "date"
-  | "datetime"
-  | "time"
-  | "localtime"
-  | "localdatetime"
-  | "duration";
+export const PRIMITIVE_TYPE_OPTIONS = [
+  "integer",
+  "string",
+  "float",
+  "boolean",
+  "point",
+  "date",
+  "datetime",
+  "time",
+  "localtime",
+  "localdatetime",
+  "duration",
+] as const;
+
+export type PrimitivePropertyTypes = (typeof PRIMITIVE_TYPE_OPTIONS)[number];

--- a/packages/graph-schema-utils/src/model/index.ts
+++ b/packages/graph-schema-utils/src/model/index.ts
@@ -295,20 +295,35 @@ export type IndexType =
 
 export type EntityType = "node" | "relationship";
 
-export type PropertyTypes = PropertyBaseType | PropertyArrayType;
-export type PropertyTypeRecursive =
-  | PropertyTypes
-  | Array<PropertyTypes | PropertyTypeRecursive[]>;
+export type PropertyType =
+  | PropertyBaseType
+  | PropertyArrayType
+  | PropertyTypeList;
+
+export type PropertyTypeList = (PropertyBaseType | PropertyArrayType)[];
+
+export const isPropertyBaseType = (p: PropertyType): p is PropertyBaseType => {
+  return p instanceof PropertyBaseType;
+}
+
+export const isPropertyArrayType = (p: PropertyType): p is PropertyArrayType => {
+  return p instanceof PropertyArrayType;
+}
+
+export const isPropertyTypeList = (p: PropertyType): p is PropertyTypeList => {
+  return Array.isArray(p);
+}
+
 export class Property {
   $id: string;
   token: string;
-  type: PropertyTypeRecursive;
+  type: PropertyType;
   nullable: boolean;
 
   constructor(
     $id: string,
     token: string,
-    type: PropertyTypeRecursive,
+    type: PropertyType,
     nullable: boolean
   ) {
     this.$id = $id;

--- a/packages/graph-schema-utils/test/model/programatical.test.ts
+++ b/packages/graph-schema-utils/test/model/programatical.test.ts
@@ -2,9 +2,8 @@ import { strict as assert } from "node:assert";
 import { describe, expect, test } from "vitest";
 import { model } from "../../src/index.js";
 import {
-  PropertyArrayType,
-  PropertyBaseType,
-  PropertyType,
+  PrimitiveArrayPropertyType,
+  PrimitivePropertyType,
   isLookupIndex,
   isNodeLabelConstraint,
   isNodeLabelIndex,
@@ -17,7 +16,7 @@ describe("Programatic model tests", () => {
       new model.Property(
         "p:Person.name",
         "name",
-        new model.PropertyBaseType("string"),
+        new model.PrimitivePropertyType("string"),
         false
       ),
     ];
@@ -30,7 +29,9 @@ describe("Programatic model tests", () => {
       new model.Property(
         "p:ACTED_IN.roles",
         "roles",
-        new model.PropertyArrayType(new model.PropertyBaseType("string")),
+        new model.PrimitiveArrayPropertyType(
+          new model.PrimitivePropertyType("string")
+        ),
         false
       ),
     ];
@@ -150,8 +151,8 @@ describe("Programatic model tests", () => {
     assert.strictEqual(
       (
         graphSchema.relationshipObjectTypes[0].type.properties[0].type as
-          | PropertyBaseType
-          | PropertyArrayType
+          | PrimitivePropertyType
+          | PrimitiveArrayPropertyType
       ).type,
       "array"
     );
@@ -170,8 +171,8 @@ describe("Programatic model tests", () => {
     assert.strictEqual(
       (
         graphSchema.constraints[0].properties[0].type as
-          | PropertyBaseType
-          | PropertyArrayType
+          | PrimitivePropertyType
+          | PrimitiveArrayPropertyType
       ).type,
       "string"
     );
@@ -196,8 +197,8 @@ describe("Programatic model tests", () => {
       assert.strictEqual(
         (
           graphSchema.indexes[0].properties[0].type as
-            | PropertyBaseType
-            | PropertyArrayType
+            | PrimitivePropertyType
+            | PrimitiveArrayPropertyType
         ).type,
         "string"
       );
@@ -217,8 +218,8 @@ describe("Programatic model tests", () => {
       assert.strictEqual(
         (
           graphSchema.indexes[1].properties[0].type as
-            | PropertyBaseType
-            | PropertyArrayType
+            | PrimitivePropertyType
+            | PrimitiveArrayPropertyType
         ).type,
         "array"
       );
@@ -301,19 +302,21 @@ describe("Programatic model tests", () => {
       new model.Property(
         "p:Person.name",
         "name",
-        new model.PropertyBaseType("string"),
+        new model.PrimitivePropertyType("string"),
         false
       ),
       new model.Property(
         "p:Dog.name",
         "name",
-        new model.PropertyBaseType("string"),
+        new model.PrimitivePropertyType("string"),
         false
       ),
       new model.Property(
         "p:ACTED_IN.roles",
         "roles",
-        new model.PropertyArrayType(new model.PropertyBaseType("string")),
+        new model.PrimitiveArrayPropertyType(
+          new model.PrimitivePropertyType("string")
+        ),
         false
       ),
     ];

--- a/packages/graph-schema-utils/test/model/programatical.test.ts
+++ b/packages/graph-schema-utils/test/model/programatical.test.ts
@@ -2,7 +2,9 @@ import { strict as assert } from "node:assert";
 import { describe, expect, test } from "vitest";
 import { model } from "../../src/index.js";
 import {
-  PropertyTypes,
+  PropertyArrayType,
+  PropertyBaseType,
+  PropertyType,
   isLookupIndex,
   isNodeLabelConstraint,
   isNodeLabelIndex,
@@ -147,8 +149,9 @@ describe("Programatic model tests", () => {
     );
     assert.strictEqual(
       (
-        graphSchema.relationshipObjectTypes[0].type.properties[0]
-          .type as PropertyTypes
+        graphSchema.relationshipObjectTypes[0].type.properties[0].type as
+          | PropertyBaseType
+          | PropertyArrayType
       ).type,
       "array"
     );
@@ -165,7 +168,11 @@ describe("Programatic model tests", () => {
       assert.strictEqual(graphSchema.constraints[0].nodeLabel, labels[0]);
     }
     assert.strictEqual(
-      (graphSchema.constraints[0].properties[0].type as PropertyTypes).type,
+      (
+        graphSchema.constraints[0].properties[0].type as
+          | PropertyBaseType
+          | PropertyArrayType
+      ).type,
       "string"
     );
     assert.strictEqual(graphSchema.constraints[1].name, "existence");
@@ -187,7 +194,11 @@ describe("Programatic model tests", () => {
       assert.strictEqual(graphSchema.indexes[0].nodeLabel, labels[0]);
       assert.strictEqual(graphSchema.indexes[0].properties.length, 1);
       assert.strictEqual(
-        (graphSchema.indexes[0].properties[0].type as PropertyTypes).type,
+        (
+          graphSchema.indexes[0].properties[0].type as
+            | PropertyBaseType
+            | PropertyArrayType
+        ).type,
         "string"
       );
     }
@@ -204,7 +215,11 @@ describe("Programatic model tests", () => {
       );
       assert.strictEqual(graphSchema.indexes[1].properties.length, 1);
       assert.strictEqual(
-        (graphSchema.indexes[1].properties[0].type as PropertyTypes).type,
+        (
+          graphSchema.indexes[1].properties[0].type as
+            | PropertyBaseType
+            | PropertyArrayType
+        ).type,
         "array"
       );
     }

--- a/packages/introspection/src/index.ts
+++ b/packages/introspection/src/index.ts
@@ -61,10 +61,11 @@ async function introspectNodes(
               Neo4jPropertyType | Neo4jPropertyArrayType
             >;
 
-            const types: (model.PropertyBaseType | model.PropertyArrayType)[] =
-              neo4jTypes.map(createPropertyInstance);
+            const types: model.PropertyType[] = neo4jTypes.map(
+              createPropertyInstance
+            );
 
-            const propertyType: model.PropertyType =
+            const propertyType: model.PropertyType | model.PropertyType[] =
               types.length === 1 ? types.pop() : types;
 
             return new model.Property(
@@ -129,7 +130,7 @@ async function introspectRelationships(
           >;
 
           const types = neo4jTypes.map(createPropertyInstance);
-          const propertyType: model.PropertyType =
+          const propertyType: model.PropertyType | model.PropertyType[] =
             types.length === 1 ? types.pop() : types;
 
           return new model.Property(
@@ -157,7 +158,9 @@ function createPropertyInstance(t: Neo4jPropertyType | Neo4jPropertyArrayType) {
   if (t.endsWith("Array")) {
     const itemType = t.slice(0, -5) as Neo4jPropertyType;
     const type = toJSONType(itemType);
-    return new model.PropertyArrayType(new model.PropertyBaseType(type));
+    return new model.PrimitiveArrayPropertyType(
+      new model.PrimitivePropertyType(type)
+    );
   }
-  return new model.PropertyBaseType(toJSONType(t as Neo4jPropertyType));
+  return new model.PrimitivePropertyType(toJSONType(t as Neo4jPropertyType));
 }

--- a/packages/introspection/src/index.ts
+++ b/packages/introspection/src/index.ts
@@ -61,12 +61,16 @@ async function introspectNodes(
               Neo4jPropertyType | Neo4jPropertyArrayType
             >;
 
-            const types = neo4jTypes.map(createPropertyInstance);
+            const types: (model.PropertyBaseType | model.PropertyArrayType)[] =
+              neo4jTypes.map(createPropertyInstance);
+
+            const propertyType: model.PropertyType =
+              types.length === 1 ? types.pop() : types;
 
             return new model.Property(
               `${nl}_${p.propertyName}`,
               p.propertyName,
-              types.length > 1 ? types : types.pop(),
+              propertyType,
               !p.mandatory
             );
           });
@@ -125,11 +129,13 @@ async function introspectRelationships(
           >;
 
           const types = neo4jTypes.map(createPropertyInstance);
+          const propertyType: model.PropertyType =
+            types.length === 1 ? types.pop() : types;
 
           return new model.Property(
             `${relType}_${p.propertyName}`,
             p.propertyName,
-            types.length > 1 ? types : types.pop(),
+            propertyType,
             !p.mandatory
           );
         });

--- a/packages/introspection/src/to-json-type.utils.ts
+++ b/packages/introspection/src/to-json-type.utils.ts
@@ -3,13 +3,13 @@ import { Neo4jPropertyType } from "./types.js";
 
 export function toJSONType(
   inType: Neo4jPropertyType
-): model.PropertyBaseType["type"] {
+): model.PrimitivePropertyType["type"] {
   switch (inType) {
     case "Long":
       return "integer";
     case "Double":
       return "float";
     default:
-      return inType.toLowerCase() as model.PropertyBaseType["type"];
+      return inType.toLowerCase() as model.PrimitivePropertyType["type"];
   }
 }

--- a/packages/introspection/src/types.ts
+++ b/packages/introspection/src/types.ts
@@ -22,7 +22,7 @@ export interface RelationshipTypePropertiesRecord extends PropertyRecord {
 }
 
 export type Neo4jPropertyType = UCFirst<
-  model.PropertyBaseType["type"] | "Long" | "Double"
+  model.PrimitivePropertyType["type"] | "Long" | "Double"
 >;
 
 export type Neo4jPropertyArrayType = `${Neo4jPropertyType}Array`;


### PR DESCRIPTION
it is not possible to define property on a node label/ relationship type as a list of list, only simple types and a homogeneous array of the same simple types are allowed.

https://neo4j.com/docs/cypher-manual/current/values-and-types/property-structural-constructed/