### PR TITLE
IMP-671 add support for vector<float32> type

### DIFF
--- a/.changeset/happy-planes-dance.md
+++ b/.changeset/happy-planes-dance.md
@@ -1,0 +1,7 @@
+---
+"@neo4j/graph-schema-utils": minor
+"@neo4j/graph-json-schema": minor
+---
+
+Adding support for vector<float32> type
+

--- a/packages/graph-schema-utils/src/formatters/json/parse.test.ts
+++ b/packages/graph-schema-utils/src/formatters/json/parse.test.ts
@@ -216,4 +216,49 @@ describe("Parser tests", () => {
     assert.strictEqual(vecType.dimension, undefined);
     assert.strictEqual(vecType.items.type, "float");
   });
+
+  test("Parses vector<float32> property", () => {
+    const schema = JSON.stringify({
+      graphSchemaRepresentation: {
+        graphSchema: {
+          nodeLabels: [
+            {
+              token: "VecFloat32Label",
+              $id: "nl:VecFloat32Label",
+              properties: [
+                {
+                  token: "embedding",
+                  $id: "p:VecFloat32Label.embedding",
+                  type: {
+                    type: "vector",
+                    items: { type: "float32" },
+                    dimension: 256
+                  },
+                  nullable: false
+                }
+              ]
+            }
+          ],
+          relationshipTypes: [],
+          nodeObjectTypes: [
+            {
+              $id: "n:VecFloat32Label",
+              labels: [{ $ref: "#nl:VecFloat32Label" }]
+            }
+          ],
+          relationshipObjectTypes: [],
+          constraints: [],
+          indexes: []
+        }
+      }
+    });
+    const parsed = fromJson(schema);
+    assert.ok(parsed.nodeLabels[0]);
+    const vecProp = parsed.nodeLabels[0].properties[0];
+    assert.strictEqual(vecProp.token, "embedding");
+    const vecType = vecProp.type as any;
+    assert.strictEqual(vecType.type, "vector");
+    assert.strictEqual(vecType.items.type, "float32");
+    assert.strictEqual(vecType.dimension, 256);
+  });
 });

--- a/packages/graph-schema-utils/src/formatters/json/serialize.test.ts
+++ b/packages/graph-schema-utils/src/formatters/json/serialize.test.ts
@@ -188,4 +188,29 @@ describe("Serializer tests", () => {
     const prop = parsed.graphSchemaRepresentation.graphSchema.nodeLabels[0].properties[0];
     expect(prop.type.dimension).toBeUndefined();
   });
+
+  test("Serializes vector<float32> property correctly", () => {
+    const nodeLabel = new model.NodeLabel("nl:VecFloat32Test", "VecFloat32Test", [
+      new model.Property(
+        "p:VecFloat32Test.vecProp",
+        "vecProp",
+        new model.VectorPropertyType(new model.VectorElementType("float32"), 128),
+        false
+      )
+    ]);
+    const nodeObjectType = new model.NodeObjectType("n:VecFloat32Test", [nodeLabel]);
+    const graphSchema = new model.GraphSchema([nodeObjectType], []);
+    const serialized = toJson(graphSchema);
+    const parsed = JSON.parse(serialized);
+    const prop = parsed.graphSchemaRepresentation.graphSchema.nodeLabels[0].properties[0];
+    expect(prop).toMatchObject({
+      token: "vecProp",
+      type: {
+        type: "vector",
+        items: { type: "float32" },
+        dimension: 128
+      },
+      nullable: false
+    });
+  });
 });

--- a/packages/graph-schema-utils/src/model/index.ts
+++ b/packages/graph-schema-utils/src/model/index.ts
@@ -402,5 +402,6 @@ export class VectorElementType {
 export const VECTOR_TYPE_OPTIONS = [
   "integer",
   "float",
+  "float32",
 ] as const;
 export type VectorElementTypes = (typeof VECTOR_TYPE_OPTIONS)[number];

--- a/packages/json-schema/json-schema.json
+++ b/packages/json-schema/json-schema.json
@@ -353,7 +353,7 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["float", "integer"]
+              "enum": ["float", "float32", "integer"]
             }
           },
           "required": ["type"],

--- a/packages/json-schema/vector-type.test.js
+++ b/packages/json-schema/vector-type.test.js
@@ -220,4 +220,39 @@ describe("json-schema vector type support", () => {
     const validate = ajv.compile(schema);
     expect(validate(data)).toBe(true);
   });
+
+  it("accepts a valid vector<float32> property", () => {
+    const data = {
+      graphSchemaRepresentation: {
+        version: "1.0.0",
+        graphSchema: {
+          nodeLabels: [
+            {
+              $id: "n1",
+              token: "Node",
+              properties: [
+                {
+                  $id: "embedding-id",
+                  token: "embedding",
+                  type: {
+                    type: "vector",
+                    items: { type: "float32" },
+                    dimension: 256
+                  },
+                  nullable: false
+                }
+              ]
+            }
+          ],
+          relationshipTypes: [],
+          nodeObjectTypes: [],
+          relationshipObjectTypes: [],
+          constraints: [],
+          indexes: []
+        }
+      }
+    };
+    const validate = ajv.compile(schema);
+    expect(validate(data)).toBe(true);
+  });
 });


### PR DESCRIPTION
IMP-671

Add float32 as a new vector element type alongside integer and float. Changes:
- Add 'float32' to VECTOR_TYPE_OPTIONS in model/index.ts
- Add 'float32' to JSON schema enum for vector item types
- Add tests for parsing and serializing vector<float32>
- Add JSON schema validation test for float32 Closes IMP-671