### PR TITLE
IMP-827: Add support for vector<integer8/16/32> types

### DIFF
--- a/.changeset/add-integer-vector-subtypes.md
+++ b/.changeset/add-integer-vector-subtypes.md
@@ -1,0 +1,6 @@
+---
+"@neo4j/graph-schema-utils": minor
+"@neo4j/graph-json-schema": minor
+---
+
+Adding support for vector<integer8>, vector<integer16> and vector<integer32> types

--- a/packages/graph-schema-utils/src/formatters/json/parse.test.ts
+++ b/packages/graph-schema-utils/src/formatters/json/parse.test.ts
@@ -351,4 +351,49 @@ describe("Parser tests", () => {
     assert.strictEqual(vecType.items.type, "integer16");
     assert.strictEqual(vecType.dimension, 128);
   });
+
+  test("Parses vector<integer32> property", () => {
+    const schema = JSON.stringify({
+      graphSchemaRepresentation: {
+        graphSchema: {
+          nodeLabels: [
+            {
+              token: "VecInteger32Label",
+              $id: "nl:VecInteger32Label",
+              properties: [
+                {
+                  token: "embedding",
+                  $id: "p:VecInteger32Label.embedding",
+                  type: {
+                    type: "vector",
+                    items: { type: "integer32" },
+                    dimension: 128
+                  },
+                  nullable: false
+                }
+              ]
+            }
+          ],
+          relationshipTypes: [],
+          nodeObjectTypes: [
+            {
+              $id: "n:VecInteger32Label",
+              labels: [{ $ref: "#nl:VecInteger32Label" }]
+            }
+          ],
+          relationshipObjectTypes: [],
+          constraints: [],
+          indexes: []
+        }
+      }
+    });
+    // ARRANGE + ACT
+    const parsed = fromJson(schema);
+    // ASSERT
+    const vecProp = parsed.nodeLabels[0].properties[0];
+    const vecType = vecProp.type as any;
+    assert.strictEqual(vecType.type, "vector");
+    assert.strictEqual(vecType.items.type, "integer32");
+    assert.strictEqual(vecType.dimension, 128);
+  });
 });

--- a/packages/graph-schema-utils/src/formatters/json/parse.test.ts
+++ b/packages/graph-schema-utils/src/formatters/json/parse.test.ts
@@ -307,4 +307,48 @@ describe("Parser tests", () => {
     assert.strictEqual(vecType.dimension, 128);
   });
 
+  test("Parses vector<integer16> property", () => {
+    const schema = JSON.stringify({
+      graphSchemaRepresentation: {
+        graphSchema: {
+          nodeLabels: [
+            {
+              token: "VecInteger16Label",
+              $id: "nl:VecInteger16Label",
+              properties: [
+                {
+                  token: "embedding",
+                  $id: "p:VecInteger16Label.embedding",
+                  type: {
+                    type: "vector",
+                    items: { type: "integer16" },
+                    dimension: 128
+                  },
+                  nullable: false
+                }
+              ]
+            }
+          ],
+          relationshipTypes: [],
+          nodeObjectTypes: [
+            {
+              $id: "n:VecInteger16Label",
+              labels: [{ $ref: "#nl:VecInteger16Label" }]
+            }
+          ],
+          relationshipObjectTypes: [],
+          constraints: [],
+          indexes: []
+        }
+      }
+    });
+    // ARRANGE + ACT
+    const parsed = fromJson(schema);
+    // ASSERT
+    const vecProp = parsed.nodeLabels[0].properties[0];
+    const vecType = vecProp.type as any;
+    assert.strictEqual(vecType.type, "vector");
+    assert.strictEqual(vecType.items.type, "integer16");
+    assert.strictEqual(vecType.dimension, 128);
+  });
 });

--- a/packages/graph-schema-utils/src/formatters/json/parse.test.ts
+++ b/packages/graph-schema-utils/src/formatters/json/parse.test.ts
@@ -300,6 +300,7 @@ describe("Parser tests", () => {
     // ARRANGE + ACT
     const parsed = fromJson(schema);
     // ASSERT
+    assert.ok(parsed.nodeLabels[0]);
     const vecProp = parsed.nodeLabels[0].properties[0];
     const vecType = vecProp.type as any;
     assert.strictEqual(vecType.type, "vector");
@@ -345,6 +346,7 @@ describe("Parser tests", () => {
     // ARRANGE + ACT
     const parsed = fromJson(schema);
     // ASSERT
+    assert.ok(parsed.nodeLabels[0]);
     const vecProp = parsed.nodeLabels[0].properties[0];
     const vecType = vecProp.type as any;
     assert.strictEqual(vecType.type, "vector");
@@ -390,6 +392,7 @@ describe("Parser tests", () => {
     // ARRANGE + ACT
     const parsed = fromJson(schema);
     // ASSERT
+    assert.ok(parsed.nodeLabels[0]);
     const vecProp = parsed.nodeLabels[0].properties[0];
     const vecType = vecProp.type as any;
     assert.strictEqual(vecType.type, "vector");

--- a/packages/graph-schema-utils/src/formatters/json/parse.test.ts
+++ b/packages/graph-schema-utils/src/formatters/json/parse.test.ts
@@ -261,4 +261,50 @@ describe("Parser tests", () => {
     assert.strictEqual(vecType.items.type, "float32");
     assert.strictEqual(vecType.dimension, 256);
   });
+
+  test("Parses vector<integer8> property", () => {
+    const schema = JSON.stringify({
+      graphSchemaRepresentation: {
+        graphSchema: {
+          nodeLabels: [
+            {
+              token: "VecInteger8Label",
+              $id: "nl:VecInteger8Label",
+              properties: [
+                {
+                  token: "embedding",
+                  $id: "p:VecInteger8Label.embedding",
+                  type: {
+                    type: "vector",
+                    items: { type: "integer8" },
+                    dimension: 128
+                  },
+                  nullable: false
+                }
+              ]
+            }
+          ],
+          relationshipTypes: [],
+          nodeObjectTypes: [
+            {
+              $id: "n:VecInteger8Label",
+              labels: [{ $ref: "#nl:VecInteger8Label" }]
+            }
+          ],
+          relationshipObjectTypes: [],
+          constraints: [],
+          indexes: []
+        }
+      }
+    });
+    // ARRANGE + ACT
+    const parsed = fromJson(schema);
+    // ASSERT
+    const vecProp = parsed.nodeLabels[0].properties[0];
+    const vecType = vecProp.type as any;
+    assert.strictEqual(vecType.type, "vector");
+    assert.strictEqual(vecType.items.type, "integer8");
+    assert.strictEqual(vecType.dimension, 128);
+  });
+
 });

--- a/packages/graph-schema-utils/src/formatters/json/serialize.test.ts
+++ b/packages/graph-schema-utils/src/formatters/json/serialize.test.ts
@@ -269,4 +269,32 @@ describe("Serializer tests", () => {
       nullable: false
     });
   });
+
+  test("Serializes vector<integer32> property correctly", () => {
+    // ARRANGE
+    const nodeLabel = new model.NodeLabel("nl:VecInteger32Test", "VecInteger32Test", [
+      new model.Property(
+        "p:VecInteger32Test.vecProp",
+        "vecProp",
+        new model.VectorPropertyType(new model.VectorElementType("integer32"), 128),
+        false
+      )
+    ]);
+    const nodeObjectType = new model.NodeObjectType("n:VecInteger32Test", [nodeLabel]);
+    const graphSchema = new model.GraphSchema([nodeObjectType], []);
+    // ACT
+    const serialized = toJson(graphSchema);
+    const parsed = JSON.parse(serialized);
+    const prop = parsed.graphSchemaRepresentation.graphSchema.nodeLabels[0].properties[0];
+    // ASSERT
+    expect(prop).toMatchObject({
+      token: "vecProp",
+      type: {
+        type: "vector",
+        items: { type: "integer32" },
+        dimension: 128
+      },
+      nullable: false
+    });
+  });
 });

--- a/packages/graph-schema-utils/src/formatters/json/serialize.test.ts
+++ b/packages/graph-schema-utils/src/formatters/json/serialize.test.ts
@@ -241,4 +241,32 @@ describe("Serializer tests", () => {
       nullable: false
     });
   });
+
+  test("Serializes vector<integer16> property correctly", () => {
+    // ARRANGE
+    const nodeLabel = new model.NodeLabel("nl:VecInteger16Test", "VecInteger16Test", [
+      new model.Property(
+        "p:VecInteger16Test.vecProp",
+        "vecProp",
+        new model.VectorPropertyType(new model.VectorElementType("integer16"), 128),
+        false
+      )
+    ]);
+    const nodeObjectType = new model.NodeObjectType("n:VecInteger16Test", [nodeLabel]);
+    const graphSchema = new model.GraphSchema([nodeObjectType], []);
+    // ACT
+    const serialized = toJson(graphSchema);
+    const parsed = JSON.parse(serialized);
+    const prop = parsed.graphSchemaRepresentation.graphSchema.nodeLabels[0].properties[0];
+    // ASSERT
+    expect(prop).toMatchObject({
+      token: "vecProp",
+      type: {
+        type: "vector",
+        items: { type: "integer16" },
+        dimension: 128
+      },
+      nullable: false
+    });
+  });
 });

--- a/packages/graph-schema-utils/src/formatters/json/serialize.test.ts
+++ b/packages/graph-schema-utils/src/formatters/json/serialize.test.ts
@@ -213,4 +213,32 @@ describe("Serializer tests", () => {
       nullable: false
     });
   });
+
+  test("Serializes vector<integer8> property correctly", () => {
+    // ARRANGE
+    const nodeLabel = new model.NodeLabel("nl:VecInteger8Test", "VecInteger8Test", [
+      new model.Property(
+        "p:VecInteger8Test.vecProp",
+        "vecProp",
+        new model.VectorPropertyType(new model.VectorElementType("integer8"), 128),
+        false
+      )
+    ]);
+    const nodeObjectType = new model.NodeObjectType("n:VecInteger8Test", [nodeLabel]);
+    const graphSchema = new model.GraphSchema([nodeObjectType], []);
+    // ACT
+    const serialized = toJson(graphSchema);
+    const parsed = JSON.parse(serialized);
+    const prop = parsed.graphSchemaRepresentation.graphSchema.nodeLabels[0].properties[0];
+    // ASSERT
+    expect(prop).toMatchObject({
+      token: "vecProp",
+      type: {
+        type: "vector",
+        items: { type: "integer8" },
+        dimension: 128
+      },
+      nullable: false
+    });
+  });
 });

--- a/packages/graph-schema-utils/src/model/index.ts
+++ b/packages/graph-schema-utils/src/model/index.ts
@@ -401,6 +401,7 @@ export class VectorElementType {
 }
 export const VECTOR_TYPE_OPTIONS = [
   "integer",
+  "integer8",
   "float",
   "float32",
 ] as const;

--- a/packages/graph-schema-utils/src/model/index.ts
+++ b/packages/graph-schema-utils/src/model/index.ts
@@ -403,6 +403,7 @@ export const VECTOR_TYPE_OPTIONS = [
   "integer",
   "integer8",
   "integer16",
+  "integer32",
   "float",
   "float32",
 ] as const;

--- a/packages/graph-schema-utils/src/model/index.ts
+++ b/packages/graph-schema-utils/src/model/index.ts
@@ -402,6 +402,7 @@ export class VectorElementType {
 export const VECTOR_TYPE_OPTIONS = [
   "integer",
   "integer8",
+  "integer16",
   "float",
   "float32",
 ] as const;

--- a/packages/json-schema/json-schema.json
+++ b/packages/json-schema/json-schema.json
@@ -353,7 +353,7 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["float", "float32", "integer"]
+              "enum": ["float", "float32", "integer", "integer8"]
             }
           },
           "required": ["type"],

--- a/packages/json-schema/json-schema.json
+++ b/packages/json-schema/json-schema.json
@@ -353,7 +353,7 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["float", "float32", "integer", "integer8", "integer16"]
+              "enum": ["float", "float32", "integer", "integer8", "integer16", "integer32"]
             }
           },
           "required": ["type"],

--- a/packages/json-schema/json-schema.json
+++ b/packages/json-schema/json-schema.json
@@ -353,7 +353,7 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["float", "float32", "integer", "integer8"]
+              "enum": ["float", "float32", "integer", "integer8", "integer16"]
             }
           },
           "required": ["type"],

--- a/packages/json-schema/json-schema.json
+++ b/packages/json-schema/json-schema.json
@@ -353,7 +353,7 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["float", "float32", "integer", "integer8", "integer16", "integer32"]
+              "enum": ["integer", "integer8", "integer16", "integer32", "float", "float32"]
             }
           },
           "required": ["type"],

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -7,13 +7,17 @@
     "url": "git+https://github.com/neo4j/graph-schema-json-js-utils.git"
   },
   "scripts": {
-    "test": "exit 0",
+    "test": "vitest run",
     "check": "exit 0",
     "build": "exit 0"
   },
   "files": [
     "json-schema.json"
   ],
+  "devDependencies": {
+    "ajv": "^8.11.0",
+    "vitest": "^0.34.3"
+  },
   "author": "",
   "license": "Apache-2.0"
 }

--- a/packages/json-schema/vector-type.test.js
+++ b/packages/json-schema/vector-type.test.js
@@ -255,4 +255,40 @@ describe("json-schema vector type support", () => {
     const validate = ajv.compile(schema);
     expect(validate(data)).toBe(true);
   });
+
+  it("accepts a valid vector<integer8> property", () => {
+    const data = {
+      graphSchemaRepresentation: {
+        version: "1.0.0",
+        graphSchema: {
+          nodeLabels: [
+            {
+              $id: "n1",
+              token: "Node",
+              properties: [
+                {
+                  $id: "embedding-id",
+                  token: "embedding",
+                  type: {
+                    type: "vector",
+                    items: { type: "integer8" },
+                    dimension: 128
+                  },
+                  nullable: false
+                }
+              ]
+            }
+          ],
+          relationshipTypes: [],
+          nodeObjectTypes: [],
+          relationshipObjectTypes: [],
+          constraints: [],
+          indexes: []
+        }
+      }
+    };
+    // ARRANGE + ACT + ASSERT
+    const validate = ajv.compile(schema);
+    expect(validate(data)).toBe(true);
+  });
 });

--- a/packages/json-schema/vector-type.test.js
+++ b/packages/json-schema/vector-type.test.js
@@ -291,4 +291,40 @@ describe("json-schema vector type support", () => {
     const validate = ajv.compile(schema);
     expect(validate(data)).toBe(true);
   });
+
+  it("accepts a valid vector<integer16> property", () => {
+    const data = {
+      graphSchemaRepresentation: {
+        version: "1.0.0",
+        graphSchema: {
+          nodeLabels: [
+            {
+              $id: "n1",
+              token: "Node",
+              properties: [
+                {
+                  $id: "embedding-id",
+                  token: "embedding",
+                  type: {
+                    type: "vector",
+                    items: { type: "integer16" },
+                    dimension: 128
+                  },
+                  nullable: false
+                }
+              ]
+            }
+          ],
+          relationshipTypes: [],
+          nodeObjectTypes: [],
+          relationshipObjectTypes: [],
+          constraints: [],
+          indexes: []
+        }
+      }
+    };
+    // ARRANGE + ACT + ASSERT
+    const validate = ajv.compile(schema);
+    expect(validate(data)).toBe(true);
+  });
 });

--- a/packages/json-schema/vector-type.test.js
+++ b/packages/json-schema/vector-type.test.js
@@ -327,4 +327,40 @@ describe("json-schema vector type support", () => {
     const validate = ajv.compile(schema);
     expect(validate(data)).toBe(true);
   });
+
+  it("accepts a valid vector<integer32> property", () => {
+    const data = {
+      graphSchemaRepresentation: {
+        version: "1.0.0",
+        graphSchema: {
+          nodeLabels: [
+            {
+              $id: "n1",
+              token: "Node",
+              properties: [
+                {
+                  $id: "embedding-id",
+                  token: "embedding",
+                  type: {
+                    type: "vector",
+                    items: { type: "integer32" },
+                    dimension: 128
+                  },
+                  nullable: false
+                }
+              ]
+            }
+          ],
+          relationshipTypes: [],
+          nodeObjectTypes: [],
+          relationshipObjectTypes: [],
+          constraints: [],
+          indexes: []
+        }
+      }
+    };
+    // ARRANGE + ACT + ASSERT
+    const validate = ajv.compile(schema);
+    expect(validate(data)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Add `integer8`, `integer16`, `integer32` as vector element subtypes
- Follows the same pattern as `vector<float32>` (IMP-671)
- Updates `VECTOR_TYPE_OPTIONS` in model/index.ts and JSON schema enum in json-schema.json

## Changes
- `packages/graph-schema-utils/src/model/index.ts` — add three new entries to `VECTOR_TYPE_OPTIONS`
- `packages/json-schema/json-schema.json` — add three new entries to vector items enum
- Tests added for each type: parse, serialize, and JSON schema validation
- Changeset added for minor version bump on both packages

## Test plan
- [x] `vector<integer8>` parses correctly from JSON
- [x] `vector<integer8>` serializes correctly to JSON
- [x] `vector<integer8>` passes JSON schema validation
- [x] Same for `integer16` and `integer32`
- [x] All existing tests still pass

Closes IMP-827