### PR TITLE
feat: add vector to IndexType in graph-schema-utils

### DIFF
--- a/.changeset/add-vector-index-type.md
+++ b/.changeset/add-vector-index-type.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graph-schema-utils": minor
+---
+
+Add "vector" to IndexType

--- a/packages/graph-schema-utils/src/model/index.ts
+++ b/packages/graph-schema-utils/src/model/index.ts
@@ -291,6 +291,7 @@ export type IndexType =
   | "text"
   | "fullText"
   | "point"
+  | "vector"
   | "default";
 
 export type EntityType = "node" | "relationship";


### PR DESCRIPTION
Closes IMP-1005

## Summary
- Adds `"vector"` to the `IndexType` union type in `packages/graph-schema-utils/src/model/index.ts`

## Test plan
- [x] Existing test suite passes