### PR TITLE
chore: add npm supply-chain protections (min-release-age, save-exact)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,7 @@
 # published for at least 3 days (matches the upx repo's minimumReleaseAge).
 # Requires npm >= 11.10.0; older npm versions silently ignore this setting.
 min-release-age=3
+
+# Pin exact versions when adding dependencies (no ^ ranges), so upgrades are
+# always an explicit, reviewable change.
+save-exact=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Supply-chain protection: only install package versions that have been
+# published for at least 3 days (matches the upx repo's minimumReleaseAge).
+# Requires npm >= 11.10.0; older npm versions silently ignore this setting.
+min-release-age=3


### PR DESCRIPTION
Implements [IMP-1082](https://linear.app/neo4j/issue/IMP-1082/make-sureinvestigate-that-graph-schema-js-json-utils-respect-the-3-day): respect the 3-day cooldown period for external packages, matching the upx baseline.

**Why**: most malicious npm versions are yanked within hours or days of publication, so a 3-day delay filters out smash-and-grab supply-chain attacks. Scope is deliberately minimal (no Dependabot/Semgrep/digest-pinning) since this repo is planned for deprecation.

Changes:

- `.npmrc` with `min-release-age=3` (requires npm >= 11.10.0) and `save-exact=true` (new deps pinned exactly, no `^` ranges).

Enforcement happens at version-resolution time, i.e. on dev machines when the lockfile is updated - `npm ci` installs from the lockfile and is unaffected, so CI needs no changes (same posture as upx, where `pnpm install --frozen-lockfile` also skips the age check). Unlike pnpm, npm has no exclusion mechanism; consuming repos that want an exception for our packages must configure it on their side (as upx does via `minimumReleaseAgeExclude`).